### PR TITLE
Add format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,58 @@
+name: Format
+
+on :
+  push:
+    branches: [ dev, main ]
+  pull_request:
+    branches: [ dev ]
+    paths-ignore:
+      - 'Docker'
+      - '**/README.md'
+      - '**/LICENCE'
+
+env:
+  INCLUDE_LINUX: true
+  INCLUDE_WINDOWS: true
+  INCLUDE_MACOS: true
+
+jobs:
+  fix-files:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install job dependencies
+      shell: bash
+      run: |
+        choco install -y dos2unix
+        curl https://www.kikisoft.com/Hive/clang-format/clang-format-7.0.0-LambdaPatch-windows.exe -o clang-format.exe 
+        ln -s $(pwd)/clang-format.exe /usr/bin/clang-format
+
+    - name: Run fix_files
+      shell: bash {0}
+      run: |
+        ./scripts/bashUtils/fix_files.sh 
+
+    - name: Check for changes
+      shell: bash
+      run: |
+        git diff --name-status --exit-code 
+        if [ $? -ne 0 ]; then
+          echo "Some files need formatting/fixing. Please run the script and commit the changes."
+          exit 1
+        fi
+
+  build-test-linux:
+    uses: ./.github/workflows/linux.yml
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: fix-files
+  build-test-windows:
+    uses: ./.github/workflows/windows.yml
+    if: ${{ github.event_name == 'pull_request'   }}
+    needs: fix-files
+  build-test-macos:
+    uses: ./.github/workflows/macos.yml
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: fix-files
+

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,12 +3,18 @@ name: Linux
 on:
   push:
     branches: [ dev, main ]
-  pull_request:
-    branches: [ dev ]
-    paths-ignore:
-      - 'Docker'
-      - '**/README.md'
-      - '**/LICENCE'
+  # pull_request:
+  #   branches: [ dev ]
+  #   paths-ignore:
+  #     - 'Docker'
+  #     - '**/README.md'
+  #     - '**/LICENCE'
+  workflow_call:
+    
+permissions:
+  contents: write
+  pull-requests: write
+  checks: write
 
 jobs:
   linux-build-and-test:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,12 +3,13 @@ name: Macos
 on:
   push:
     branches: [ dev, main ]
-  pull_request:
-    branches: [ dev ]
-    paths-ignore:
-      - 'Docker'
-      - '**/README.md'
-      - '**/LICENCE'
+  # pull_request:
+  #   branches: [ dev ]
+  #   paths-ignore:
+  #     - 'Docker'
+  #     - '**/README.md'
+  #     - '**/LICENCE'
+  workflow_call:
 
 jobs:
   macos-build-and-test:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,12 +4,13 @@ name: Windows
 on:
   push:
     branches: [ dev, main ]
-  pull_request:
-    branches: [ dev ]
-    paths-ignore:
-      - 'Docker'
-      - '**/README.md'
-      - '**/LICENCE'
+  # pull_request:
+  #   branches: [ dev ]
+  #   paths-ignore:
+  #     - 'Docker'
+  #     - '**/README.md'
+  #     - '**/LICENCE'
+  workflow_call:
 
 jobs:
   windows-build-and-test:

--- a/include/la/networkInterfaceHelper/networkInterfaceHelper.hpp
+++ b/include/la/networkInterfaceHelper/networkInterfaceHelper.hpp
@@ -79,8 +79,12 @@ public:
 		V6,
 	};
 
-	static struct CompatibleV6Tag{} CompatibleV6;
-	static struct MappedV6Tag{} MappedV6;
+	static struct CompatibleV6Tag
+	{
+	} CompatibleV6;
+	static struct MappedV6Tag
+	{
+	} MappedV6;
 
 	/** Default constructor. */
 	IPAddress() noexcept;


### PR DESCRIPTION
This pr adds the workflow steps to run the fix_files script (format) before any build steps. The workflow will fail if any files get changed during the process.

This PR also uses a custom version of the `fix_files.sh` that can ignore submodules files.